### PR TITLE
Add support for building and publishing multiarch container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Test
         run: go test -v ./...
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+project_name: mc-monitor
 before:
   hooks:
     - go mod download
@@ -21,37 +22,46 @@ archives:
         format: zip
 dockers:
   - image_templates:
-      -  itzg/mc-monitor:latest-amd64
+      -  itzg/{{ .ProjectName }}:{{ .Version }}-amd64
     dockerfile: Dockerfile.release
     use: buildx
     build_flag_templates:
-      - --platform=linux/amd64
+      - --platform
+      - linux/amd64
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
   - image_templates:
-      -  itzg/mc-monitor:latest-arm64
+      -  itzg/{{ .ProjectName }}:{{ .Version }}-arm64
     dockerfile: Dockerfile.release
     goarch: arm64
     use: buildx
     build_flag_templates:
-      - --platform=linux/arm64
+      - --platform
+      - linux/arm64
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
   - image_templates:
-      -  itzg/mc-monitor:latest-arm-v7
+      -  itzg/{{ .ProjectName }}:{{ .Version }}-arm32v7
     dockerfile: Dockerfile.release
     goarch: arm
     goarm: "7"
     use: buildx
     build_flag_templates:
-      - --platform=linux/arm/v7
+      - --platform
+      - linux/arm/v7
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
 docker_manifests:
-  - name_template:  itzg/mc-monitor:{{ .Tag }}
+  - name_template:  itzg/{{ .ProjectName }}:{{ .Version }}
     image_templates:
-      -  itzg/mc-monitor:latest-amd64
-      -  itzg/mc-monitor:latest-arm64
-      -  itzg/mc-monitor:latest-arm-v7
-  - name_template:  itzg/mc-monitor:latest
+      -  itzg/{{ .ProjectName }}:latest-amd64
+      -  itzg/{{ .ProjectName }}:latest-arm64
+      -  itzg/{{ .ProjectName }}:latest-arm32v7
+  - name_template:  itzg/{{ .ProjectName }}:latest
     image_templates:
-      -  itzg/mc-monitor:latest-amd64
-      -  itzg/mc-monitor:latest-arm64
-      -  itzg/mc-monitor:latest-arm-v7
+      -  itzg/{{ .ProjectName }}:latest-amd64
+      -  itzg/{{ .ProjectName }}:latest-arm64
+      -  itzg/{{ .ProjectName }}:latest-arm32v7
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,9 +21,37 @@ archives:
         format: zip
 dockers:
   - image_templates:
-      - itzg/mc-monitor:latest
-      - itzg/mc-monitor:{{ .Tag }}
+      -  itzg/mc-monitor:latest-amd64
     dockerfile: Dockerfile.release
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/amd64
+  - image_templates:
+      -  itzg/mc-monitor:latest-arm64
+    dockerfile: Dockerfile.release
+    goarch: arm64
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/arm64
+  - image_templates:
+      -  itzg/mc-monitor:latest-arm-v7
+    dockerfile: Dockerfile.release
+    goarch: arm
+    goarm: "7"
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/arm/v7
+docker_manifests:
+  - name_template:  itzg/mc-monitor:{{ .Tag }}
+    image_templates:
+      -  itzg/mc-monitor:latest-amd64
+      -  itzg/mc-monitor:latest-arm64
+      -  itzg/mc-monitor:latest-arm-v7
+  - name_template:  itzg/mc-monitor:latest
+    image_templates:
+      -  itzg/mc-monitor:latest-amd64
+      -  itzg/mc-monitor:latest-arm64
+      -  itzg/mc-monitor:latest-arm-v7
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Uses GoReleaser's support for [docker manifests](https://goreleaser.com/customization/docker_manifest/) to build and push a multiarch image. Only configured for linux variants.

Tested [here](https://github.com/zlangbert/mc-monitor/runs/4291252355?check_suite_focus=true) with images pushed [here](https://hub.docker.com/r/zlangbert/mc-monitor). I successfully pulled `zlangbert/mc-monitor` on an arm64 node.