### PR TITLE
Feature: add experimental flag to use the mcutils library for pings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ docker run -it --rm itzg/mc-monitor status-bedrock --host play.fallentech.io
 
 where exit code will be 0 for success or 1 for failure.
 
+### Workarounds for some status errors
+
+Some Forge servers may cause a `string length out of bounds` error during status messages due to how the [FML2 protocol](https://wiki.vg/Minecraft_Forge_Handshake#FML2_protocol_.281.13_-_Current.29) bundles the entire modlist for client compatibility check. If there are issues with `status` failing when it otherwise should work, you can try out the experimental `--use-mc-utils` flag below (enables the [mcutils](https://github.com/xrjr/mcutils) protocol library):
+```
+docker run -it --rm itzg/mc-monitor status --use-mc-utils --host play.fallentech.io
+```
+
 ### Monitoring a server with Telegraf
 
 > The following example is provided in [examples/mc-monitor-telegraf](examples/mc-monitor-telegraf)

--- a/go.mod
+++ b/go.mod
@@ -4,33 +4,34 @@ go 1.17
 
 require (
 	github.com/Raqbit/mc-pinger v0.2.2
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/google/subcommands v1.2.0
-	github.com/iancoleman/strcase v0.1.3 // indirect
-	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 // indirect
 	github.com/itzg/go-flagsfiller v1.5.0
 	github.com/itzg/line-protocol-sender v0.1.1
 	github.com/itzg/zapconfigs v0.1.0
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/pires/go-proxyproto v0.6.0 // indirect
 	github.com/prometheus/client_golang v1.11.0
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.26.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/sandertv/go-raknet v1.10.0
 	github.com/stretchr/testify v1.7.0
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
+	github.com/xrjr/mcutils v1.3.2
 	go.uber.org/zap v1.19.1
-	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
 )
 
 require (
-	github.com/avast/retry-go v3.0.0+incompatible // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/iancoleman/strcase v0.1.3 // indirect
+	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pires/go-proxyproto v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/xrjr/mcutils v1.3.2 h1:AApQqiVrzNhXyggMIjW82x0EWzsQf4MTRtM0ebFjJ9E=
+github.com/xrjr/mcutils v1.3.2/go.mod h1:43n8cyMIHYjiRM2LFZLVH5Ppz2+RvWppz6OgkLP8Lsk=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=


### PR DESCRIPTION
@xrjr has made a library called [mcutils](https://github.com/xrjr/mcutils) that seems to be a slightly more complete implementation of the [1.7+ server list ping](https://wiki.vg/Server_List_Ping#Current_.281.7.2B.29) & [FML2 protocol extension](https://wiki.vg/Minecraft_Forge_Handshake#FML2_protocol_.281.13_-_Current.29)

### Changes
- Added flag `--use-mc-utils` to enable the mcutils ping behavior
- Sprinkle of debug messages as I didn't see integration tests to extend
- Confirmed working on a live 1.16.5 modded forge server running Enigmatica 6 v1.5.1
- Duplicated existing pattern for legacy server list ping, but it could be more DRY

### Motivation
This relates to #21 as it provides a mechanism for solving that error by using a different MC protocol API behind an experimental flag that handles FML2 protocol decorations more gracefully.

### Why put this behind an experimental flag?
I don't feel comfortable (yet) suggesting [mcutils](https://github.com/xrjr/mcutils) as a full replacement for [mc-pinger](https://github.com/Raqbit/mc-pinger) without more extensive testing. While the mcutils implementation is more complete and it's very well documented, it _is_ lacking test coverage and ~~one of its packages (query) also broke against my Forge server~~ it works fine, this was user error. Ping seems to be all that's needed for mc-monitor, it has all the fields we normally want, and I'm not fussy about it for a cheap fork. Still, I thought it was worth socializing the fix in case it's useful to other people somehow.

Edit: correction on `query`