### PR TITLE
feature: add argument `timeout` (environ `TIMEOUT`) for Prometheus exporter mode

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -20,9 +20,15 @@ type BedrockServerInfo struct {
 	Rtt             time.Duration
 }
 
-func PingBedrockServer(address string) (*BedrockServerInfo, error) {
+func PingBedrockServer(address string, timeout time.Duration) (*BedrockServerInfo, error) {
 	start := time.Now()
-	response, err := raknet.Ping(address)
+	var response []byte
+	var err error
+	if timeout > 0 {
+		response, err = raknet.PingTimeout(address, timeout)
+	} else {
+		response, err = raknet.Ping(address)
+	}
 	rtt := time.Now().Sub(start)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query bedrock server %s: %w", address, err)

--- a/bedrock_status.go
+++ b/bedrock_status.go
@@ -47,7 +47,7 @@ func (c *statusBedrockCmd) Execute(ctx context.Context, f *flag.FlagSet, args ..
 	}
 
 	for {
-		info, err := PingBedrockServer(address)
+		info, err := PingBedrockServer(address, 0)
 		if err != nil {
 			if c.RetryLimit > 0 {
 				c.RetryLimit--


### PR DESCRIPTION
Currently there is no timeout mechanism in Prometheus exporter mode, which will cause the metrics request hangs forever if the server is not reachable. This patch adds a CLI switch `-timeout` and an environment variable config `TIMEOUT` which is identical to [this PR](https://github.com/itzg/mc-monitor/pull/4).

Tested with the latest Prometheus docker image.