### PR TITLE
Java status needs to continue retries even when network error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.21.6"
+      go-version: "1.22.2"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.21.6"
+      go-version: "1.22.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /build
 
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -o mc-monitor
+RUN CGO_ENABLED=0 go build -buildvcs=false -o mc-monitor
 
 FROM scratch
 ENTRYPOINT ["/mc-monitor"]


### PR DESCRIPTION
The openj9 builds of docker-minecraft-server started failing during tests with an error like the following. My guess is that the DNS entry or Docker's DNS is not yet ready on first ping, an error is returned, but the old retry logic was very primitive and just bailed.

```
failed to ping mc:25565 : could not connect to Minecraft server: dial tcp: lookup mc on 127.0.0.11:53: server misbehaving Container multi-part-motd-monitor-run-7a4475c13f6a  Stopping
```

This new code uses the avast/retry-go library like other parts of the code already were doing.

Also upgrades Go to 1.22.2