### PR TITLE
fix docker-compose.yml flags for OpenTelemetry

### DIFF
--- a/examples/mc-monitor-otel/docker-compose.yml
+++ b/examples/mc-monitor-otel/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   # Initialize the monitor
   monitor:
     image: itzg/mc-monitor
-    command: ['collect-otel', '-exporter-endpoint=otel_collector:4317', '-exporter-timeout=35s']
+    command: ['collect-otel', '-otel-collector-endpoint=otel_collector:4317','-otel-collector-timeout=35s']
     environment:
       EXPORT_SERVERS: mc
       DEBUG: "true"


### PR DESCRIPTION
### Description:
While using the `examples/mc-monitor-otel/docker-compose.yml` file, the following error was encountered:

```
2024-08-23 21:23:56 flag provided but not defined: -exporter.endpoint
2024-08-23 21:23:56   -bedrock-servers host:port
2024-08-23 21:23:56             one or more host:port addresses of Bedrock servers to monitor, when port is omitted 19132 is used (env EXPORT_BEDROCK_SERVERS)
2024-08-23 21:23:56   -interval duration
2024-08-23 21:23:56             Collect and sends OpenTelemetry data at this interval (env EXPORT_INTERVAL) (default 10s)
2024-08-23 21:23:56   -otel-collector-endpoint string
2024-08-23 21:23:56             OpenTelemetry gRPC endpoint to export data (env EXPORT_OTEL_COLLECTOR_ENDPOINT) (default "localhost:4317")
2024-08-23 21:23:56   -otel-collector-timeout duration
2024-08-23 21:23:56             Timeout for collecting OpenTelemetry data (env EXPORT_OTEL_COLLECTOR_TIMEOUT) (default 35s)
2024-08-23 21:23:56   -servers host:port
2024-08-23 21:23:56             one or more host:port addresses of Java servers to monitor, when port is omitted 25565 is used (env EXPORT_SERVERS) (default mc)
```
