### PR TITLE
Fix for otel meter reporting stale data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 
 WORKDIR /build
 

--- a/otel/cmd.go
+++ b/otel/cmd.go
@@ -162,6 +162,7 @@ func (c *CollectOpenTelemetryCmd) initializeMetricResources() (
 			host,
 			port,
 			withServerEdition(utils.JavaEdition),
+			withServerMetrics(c.logger),
 			withLogger(c.logger),
 		)
 		if err != nil {


### PR DESCRIPTION
Change summary:

- moving metrics data to a ServerMetrics instance so that the otel observer callback can read up-to-date values 
- Adding additional debug logging to otel module 
- Small tweak to dockerfile to address warning message 

I found an issue with the otel reporting module where it seemed that the observer callback functions were taking a snapshot of whatever the first values passed to the record methods happened to be. Subsequent calls to the record methods didn’t seem to be updating the values and the result was that my otel collector would receive a stream of identical values. Only restarting the mc-monitor container would cause new values to be sent. 

I’ve modified the callback functions to read values from an instance of the ServerMetrics struct. I’ve also modified the logic in the otel resource Execute method to track a single instance of ServerMetrics. 

My setup only has a single Java MC server to monitor, so I haven’t tested with multiple servers or bedrock servers, but I’m hoping that referencing an instance of ServerMetrics per resource instance should prevent conflicts between server targets.

These changes do result in new data being sent each tick, but it seems that the observer still reads the values from the previous tick. There may still be a race condition between when the observer callbacks execute and when the pinger returns and updates the metric values. I’m not experienced with Go, so I didn’t want to make any sweeping structural changes to try to address that. I’m thinking that the tool’s otel mode will still be useful if the metrics are only 1 tick old when they get sent. 