### PR TITLE
Added: RISCV64 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,11 +15,16 @@ builds:
     - amd64
     - arm
     - arm64
+    - riscv64
   goarm:
     - "7"
   ignore:
     - goos: windows
       goarch: arm
+    - goos: windows
+      goarch: riscv64
+    - goos: darwin
+      goarch: riscv64
 dockers:
   - image_templates:
       -  itzg/{{ .ProjectName }}:{{ .Version }}-amd64


### PR DESCRIPTION
I would like to add RISCV64 in project [docker-minecraft-server](https://github.com/itzg/docker-minecraft-server).
So this is the third step!