### PR TITLE
Handle shorter ping response in status-bedrock

### DIFF
--- a/bedrock.go
+++ b/bedrock.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/sandertv/go-raknet"
+	"go.uber.org/zap"
+
 	"strconv"
 	"strings"
 	"time"
@@ -20,7 +23,7 @@ type BedrockServerInfo struct {
 	Rtt             time.Duration
 }
 
-func PingBedrockServer(address string, timeout time.Duration) (*BedrockServerInfo, error) {
+func PingBedrockServer(address string, timeout time.Duration, logger *zap.Logger) (*BedrockServerInfo, error) {
 	start := time.Now()
 	var response []byte
 	var err error
@@ -34,22 +37,36 @@ func PingBedrockServer(address string, timeout time.Duration) (*BedrockServerInf
 		return nil, fmt.Errorf("failed to query bedrock server %s: %w", address, err)
 	}
 
+	logger.Debug("received response from bedrock server", zap.String("address", address), zap.ByteString("response", response))
 	parts := strings.Split(string(response), ";")
 	info := &BedrockServerInfo{
 		Rtt:             rtt,
 		ServerName:      parts[1],
 		ProtocolVersion: parts[2],
 		Version:         parts[3],
-		Players:         safeParseInt(parts[4]),
-		MaxPlayers:      safeParseInt(parts[5]),
-		LevelName:       parts[7],
-		GameMode:        parts[8],
-	}
-	if len(parts) >= 10 {
-		info.Difficulty = parts[9]
+		// the parts past here are not always present in the response
+		Players:    safeIntAt(parts, 4),
+		MaxPlayers: safeIntAt(parts, 5),
+		LevelName:  safeStringAt(parts, 7),
+		GameMode:   safeStringAt(parts, 8),
+		Difficulty: safeStringAt(parts, 9),
 	}
 
 	return info, nil
+}
+
+func safeStringAt(parts []string, index int) string {
+	if index >= 0 && index < len(parts) {
+		return parts[index]
+	}
+	return ""
+}
+
+func safeIntAt(parts []string, index int) int {
+	if index >= 0 && index < len(parts) {
+		return safeParseInt(parts[index])
+	}
+	return -1
 }
 
 func safeParseInt(s string) int {

--- a/bedrock_status.go
+++ b/bedrock_status.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"github.com/google/subcommands"
 	"github.com/itzg/go-flagsfiller"
+	"go.uber.org/zap"
+
 	"log"
 	"net"
 	"strconv"
@@ -40,21 +43,22 @@ func (c *statusBedrockCmd) SetFlags(flags *flag.FlagSet) {
 	}
 }
 
-func (c *statusBedrockCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+func (c *statusBedrockCmd) Execute(_ context.Context, _ *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	logger := args[0].(*zap.Logger)
 	address := net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
 	if c.RetryInterval <= 0 {
 		c.RetryInterval = 1 * time.Second
 	}
 
 	for {
-		info, err := PingBedrockServer(address, 0)
+		info, err := PingBedrockServer(address, 0, logger)
 		if err != nil {
 			if c.RetryLimit > 0 {
 				c.RetryLimit--
 				time.Sleep(c.RetryInterval)
 				continue
 			}
-			log.Fatal(err)
+			logger.Fatal("Failed to ping Bedrock server", zap.Error(err))
 			return subcommands.ExitFailure
 		}
 

--- a/prom_collector.go
+++ b/prom_collector.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	mcpinger "github.com/Raqbit/mc-pinger"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 	"net"
 	"strconv"
 	"time"
+
+	mcpinger "github.com/Raqbit/mc-pinger"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 )
 
 const (
@@ -202,7 +203,7 @@ func newPromBedrockCollector(host string, port uint16, logger *zap.Logger) *prom
 func (c *promBedrockCollector) Collect(metrics chan<- prometheus.Metric) {
 	c.logger.Debug("pinging", zap.String("host", c.host), zap.String("port", strconv.Itoa(int(c.port))))
 
-	info, err := PingBedrockServer(net.JoinHostPort(c.host, strconv.Itoa(int(c.port))), c.timeout)
+	info, err := PingBedrockServer(net.JoinHostPort(c.host, strconv.Itoa(int(c.port))), c.timeout, c.logger)
 	if err != nil {
 		c.sendMetric(metrics, promDescHealthy, "", 0)
 	} else {


### PR DESCRIPTION
Addresses [the issue reported in this comment](https://github.com/itzg/docker-minecraft-bedrock-server/issues/649#issuecomment-4903505803)

```
panic: runtime error: index out of range [4] with length 1

goroutine 1 [running]:
main.PingBedrockServer({0x9ad70209da0, 0xe}, 0x0)
  /home/runner/work/mc-monitor/mc-monitor/bedrock.go:43 +0x3ea
main.(*statusBedrockCmd).Execute(0x9ad70381770, {0x9ad702001a0?, 0x7f2d3de0b228?}, 0x7f2d3e0dca00?, {0x10?, 0x9ad701b9008?, 0x9ad7022b590?})
  /home/runner/work/mc-monitor/mc-monitor/bedrock_status.go:50 +0x11e
github.com/google/subcommands.(*Commander).Execute(0x9ad70266000, {0xd36930, 0x9ad7026f270}, {0x9ad7022b590, 0x1, 0x1})
  /home/runner/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x38d
github.com/google/subcommands.Execute(...)
  /home/runner/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
  /home/runner/work/mc-monitor/mc-monitor/main.go:74 +0x16c5
```