### PR TITLE
Add proxy protocol support to Prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,14 @@ mc-monitor status --help
     	one or more host:port addresses of Bedrock servers to monitor, when port is omitted 19132 is used (env EXPORT_BEDROCK_SERVERS)
   -port int
     	HTTP port where Prometheus metrics are exported (env EXPORT_PORT) (default 8080)
+  -proxy-version uint
+        version of PROXY protocol to use (env EXPORT_PROXY_VERSION) (default 1)
   -servers host:port
     	one or more host:port addresses of Java servers to monitor, when port is omitted 25565 is used (env EXPORT_SERVERS)
   -timeout duration
     	timeout when checking each servers (env TIMEOUT) (default 1m0s)
+  -use-proxy
+        supports contacting servers when proxy_protocol is enabled (env EXPORT_USE_PROXY)
 ```
 
 ### gather-for-telegraf
@@ -190,8 +194,14 @@ The sub-command accepts the following arguments, which can also be viewed using 
     	one or more host:port addresses of Bedrock servers to monitor, when port is omitted 19132 is used (env EXPORT_BEDROCK_SERVERS)
   -port int
     	HTTP port where Prometheus metrics are exported (env EXPORT_PORT) (default 8080)
+  -proxy-version uint
+        version of PROXY protocol to use (env EXPORT_PROXY_VERSION) (default 1)
   -servers host:port
     	one or more host:port addresses of Java servers to monitor, when port is omitted 25565 is used (env EXPORT_SERVERS)
+  -timeout duration
+        timeout when checking each servers (env TIMEOUT) (default 1m0s)
+  -use-proxy
+        supports contacting servers when proxy_protocol is enabled (env EXPORT_USE_PROXY)
 ```
 
 The following metrics are exported

--- a/prom_cmd.go
+++ b/prom_cmd.go
@@ -21,6 +21,8 @@ type exportPrometheusCmd struct {
 	BedrockServers []string      `usage:"one or more [host:port] addresses of Bedrock servers to monitor, when port is omitted 19132 is used"`
 	Port           int           `usage:"HTTP port where Prometheus metrics are exported" default:"8080"`
 	Timeout        time.Duration `usage:"timeout when checking each servers" default:"60s" env:"TIMEOUT"`
+	UseProxy       bool          `usage:"supports contacting servers when proxy_protocol is enabled"`
+	ProxyVersion   uint          `usage:"version of PROXY protocol to use" default:"1"`
 	logger         *zap.Logger
 }
 
@@ -52,7 +54,7 @@ func (c *exportPrometheusCmd) Execute(_ context.Context, _ *flag.FlagSet, args .
 
 	logger := args[0].(*zap.Logger)
 
-	collectors, err := newPromCollectors(c.Servers, c.BedrockServers, logger)
+	collectors, err := newPromCollectors(c.Servers, c.BedrockServers, c.UseProxy, c.ProxyVersion, logger)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/prom_cmd_test.go
+++ b/prom_cmd_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportPrometheusProxyFlags(t *testing.T) {
+	t.Setenv("EXPORT_USE_PROXY", "false")
+	t.Setenv("EXPORT_PROXY_VERSION", "1")
+
+	cmd := &exportPrometheusCmd{}
+	flags := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	cmd.SetFlags(flags)
+
+	err := flags.Parse([]string{"-servers", "localhost", "-use-proxy", "-proxy-version", "2"})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"localhost"}, cmd.Servers)
+	require.True(t, cmd.UseProxy)
+	require.Equal(t, uint(2), cmd.ProxyVersion)
+	require.Equal(t, time.Minute, cmd.Timeout)
+}
+
+func TestExportPrometheusProxyEnvironment(t *testing.T) {
+	t.Setenv("EXPORT_USE_PROXY", "true")
+	t.Setenv("EXPORT_PROXY_VERSION", "2")
+
+	cmd := &exportPrometheusCmd{}
+	flags := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	cmd.SetFlags(flags)
+
+	require.True(t, cmd.UseProxy)
+	require.Equal(t, uint(2), cmd.ProxyVersion)
+}

--- a/prom_collector.go
+++ b/prom_collector.go
@@ -38,13 +38,23 @@ type pingOptions interface {
 	GetHost() string
 	GetPort() uint16
 	GetTimeout() time.Duration
+	GetUseProxy() bool
+	GetProxyVersion() byte
 }
 
-func pingJavaServer(opt pingOptions) (*mcpinger.ServerInfo, error) {
+func javaPingerOptions(opt pingOptions) []mcpinger.McPingerOption {
 	var opts []mcpinger.McPingerOption
 	if t := opt.GetTimeout(); t > 0 {
 		opts = append(opts, mcpinger.WithTimeout(t))
 	}
+	if opt.GetUseProxy() {
+		opts = append(opts, mcpinger.WithProxyProto(opt.GetProxyVersion()))
+	}
+	return opts
+}
+
+func pingJavaServer(opt pingOptions) (*mcpinger.ServerInfo, error) {
+	opts := javaPingerOptions(opt)
 	pinger := mcpinger.New(opt.GetHost(), opt.GetPort(), opts...)
 	return pinger.Ping()
 }
@@ -69,16 +79,20 @@ func (c promCollectors) Collect(metrics chan<- prometheus.Metric) {
 	}
 }
 
-func newPromCollectors(servers []string, bedrockServers []string, logger *zap.Logger) (promCollectors, error) {
+func newPromCollectors(servers []string, bedrockServers []string, useProxy bool, proxyVersion uint, logger *zap.Logger) (promCollectors, error) {
 	var collectors []specificPromCollector
 
-	javaCollectors, err := createPromCollectors(servers, JavaEdition, logger)
+	if useProxy && proxyVersion != 1 && proxyVersion != 2 {
+		return nil, fmt.Errorf("proxy version must be 1 or 2")
+	}
+
+	javaCollectors, err := createPromCollectors(servers, JavaEdition, useProxy, byte(proxyVersion), logger)
 	if err != nil {
 		return nil, err
 	}
 	collectors = append(collectors, javaCollectors...)
 
-	bedrockCollectors, err := createPromCollectors(bedrockServers, BedrockEdition, logger)
+	bedrockCollectors, err := createPromCollectors(bedrockServers, BedrockEdition, false, 0, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +101,7 @@ func newPromCollectors(servers []string, bedrockServers []string, logger *zap.Lo
 	return collectors, nil
 }
 
-func createPromCollectors(servers []string, edition ServerEdition, logger *zap.Logger) (collectors []specificPromCollector, err error) {
+func createPromCollectors(servers []string, edition ServerEdition, useProxy bool, proxyVersion byte, logger *zap.Logger) (collectors []specificPromCollector, err error) {
 	for _, server := range servers {
 		switch edition {
 
@@ -96,7 +110,7 @@ func createPromCollectors(servers []string, edition ServerEdition, logger *zap.L
 			if err != nil {
 				return nil, fmt.Errorf("failed to process server entry '%s': %w", server, err)
 			}
-			collectors = append(collectors, newPromJavaCollector(host, port, logger))
+			collectors = append(collectors, newPromJavaCollector(host, port, useProxy, proxyVersion, logger))
 
 		case BedrockEdition:
 			host, port, err := SplitHostPort(server, DefaultBedrockPort)
@@ -109,19 +123,23 @@ func createPromCollectors(servers []string, edition ServerEdition, logger *zap.L
 	return
 }
 
-func newPromJavaCollector(host string, port uint16, logger *zap.Logger) specificPromCollector {
+func newPromJavaCollector(host string, port uint16, useProxy bool, proxyVersion byte, logger *zap.Logger) specificPromCollector {
 	return &promJavaCollector{
-		host:   host,
-		port:   port,
-		logger: logger,
+		host:         host,
+		port:         port,
+		logger:       logger,
+		useProxy:     useProxy,
+		proxyVersion: proxyVersion,
 	}
 }
 
 type promJavaCollector struct {
-	host    string
-	port    uint16
-	logger  *zap.Logger
-	timeout time.Duration
+	host         string
+	port         uint16
+	logger       *zap.Logger
+	timeout      time.Duration
+	useProxy     bool
+	proxyVersion byte
 }
 
 func (c *promJavaCollector) GetHost() string {
@@ -134,6 +152,14 @@ func (c *promJavaCollector) GetPort() uint16 {
 
 func (c *promJavaCollector) GetTimeout() time.Duration {
 	return c.timeout
+}
+
+func (c *promJavaCollector) GetUseProxy() bool {
+	return c.useProxy
+}
+
+func (c *promJavaCollector) GetProxyVersion() byte {
+	return c.proxyVersion
 }
 
 func (c *promJavaCollector) SetTimeout(t time.Duration) {

--- a/prom_collector_test.go
+++ b/prom_collector_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	mcpinger "github.com/Raqbit/mc-pinger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestJavaPingerOptions(t *testing.T) {
+	tests := []struct {
+		name               string
+		useProxy           bool
+		proxyVersion       byte
+		expectProxy        bool
+		expectProxyVersion byte
+	}{
+		{name: "disabled", useProxy: false, proxyVersion: 2},
+		{name: "version one", useProxy: true, proxyVersion: 1, expectProxy: true, expectProxyVersion: 1},
+		{name: "version two", useProxy: true, proxyVersion: 2, expectProxy: true, expectProxyVersion: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := &promJavaCollector{
+				timeout:      5 * time.Second,
+				useProxy:     tt.useProxy,
+				proxyVersion: tt.proxyVersion,
+			}
+			pinger := mcpinger.New("localhost", DefaultJavaPort, javaPingerOptions(collector)...)
+			value := reflect.ValueOf(pinger).Elem()
+
+			assert.Equal(t, 5*time.Second, time.Duration(value.FieldByName("Timeout").Int()))
+			assert.Equal(t, tt.expectProxy, value.FieldByName("UseProxy").Bool())
+			assert.Equal(t, uint64(tt.expectProxyVersion), value.FieldByName("ProxyVersion").Uint())
+		})
+	}
+}
+
+func TestNewPromCollectorsPropagatesProxyConfig(t *testing.T) {
+	collectors, err := newPromCollectors(
+		[]string{"java.example.com"},
+		[]string{"bedrock.example.com"},
+		true,
+		2,
+		zap.NewNop(),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, collectors, 2)
+
+	javaCollector, ok := collectors[0].(*promJavaCollector)
+	require.True(t, ok)
+	assert.True(t, javaCollector.useProxy)
+	assert.Equal(t, byte(2), javaCollector.proxyVersion)
+
+	_, ok = collectors[1].(*promBedrockCollector)
+	require.True(t, ok)
+}
+
+func TestNewPromCollectorsRejectsInvalidProxyVersion(t *testing.T) {
+	_, err := newPromCollectors([]string{"java.example.com"}, nil, true, 3, zap.NewNop())
+
+	require.EqualError(t, err, "proxy version must be 1 or 2")
+}


### PR DESCRIPTION
Adds `-use-proxy` and `-proxy-version` to `export-for-prometheus` and passes them through to Java server pings. The same settings are available through `EXPORT_USE_PROXY` and `EXPORT_PROXY_VERSION`.

Includes coverage for CLI and environment parsing, collector propagation, and the mc-pinger options. Invalid protocol versions are rejected before collector setup.

Closes #113

Tests:
- `go test ./...`
- `go vet ./...`
- `go build ./...`
